### PR TITLE
Added functionality for when the battery dies

### DIFF
--- a/final/heartwave.cpp
+++ b/final/heartwave.cpp
@@ -4,6 +4,7 @@
 HeartWave::HeartWave(Mediator* mediator)
 {
     this -> mediator = mediator;
+    this -> battery = 100;
 
     this -> coherence = new Coherence();
     this -> log = new Log();

--- a/final/heartwave.h
+++ b/final/heartwave.h
@@ -47,7 +47,7 @@ private:
     Coherence *coherence;
     Log *log;
 
-    float battery = 100;
+    float battery;
     double session_time = 0.0;
 
     std::deque<int> heartbeats;

--- a/final/mainwindow.h
+++ b/final/mainwindow.h
@@ -21,6 +21,7 @@ public:
     void createGraph();
     void addData(int, int);
     void clearGraph();
+    void powerOffBattery();
 
 private slots:
     void update();

--- a/final/mainwindow.ui
+++ b/final/mainwindow.ui
@@ -210,42 +210,13 @@ background-color: FF0000;
     <property name="geometry">
      <rect>
       <x>100</x>
-      <y>150</y>
+      <y>120</y>
       <width>80</width>
       <height>25</height>
      </rect>
     </property>
     <property name="text">
      <string>Set Settings</string>
-    </property>
-   </widget>
-   <widget class="QSpinBox" name="challengeLevel">
-    <property name="geometry">
-     <rect>
-      <x>190</x>
-      <y>110</y>
-      <width>45</width>
-      <height>26</height>
-     </rect>
-    </property>
-    <property name="minimum">
-     <number>1</number>
-    </property>
-    <property name="maximum">
-     <number>4</number>
-    </property>
-   </widget>
-   <widget class="QLabel" name="challengeLevelLabel">
-    <property name="geometry">
-     <rect>
-      <x>60</x>
-      <y>110</y>
-      <width>181</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Challenge Level</string>
     </property>
    </widget>
    <widget class="QOpenGLWidget" name="deviceBackground">
@@ -415,8 +386,6 @@ background-color: FF0000;
    <zorder>breathPacer</zorder>
    <zorder>settingsLabel</zorder>
    <zorder>setSettings</zorder>
-   <zorder>challengeLevelLabel</zorder>
-   <zorder>challengeLevel</zorder>
    <zorder>leftButton</zorder>
    <zorder>rightButton</zorder>
    <zorder>okButton</zorder>

--- a/final/mediator.cpp
+++ b/final/mediator.cpp
@@ -7,9 +7,8 @@ Mediator::Mediator(MainWindow* window)
     hv = new HeartWave(this);  // TODO: might have parameters
 }
 
-void Mediator::updateSettings(int breathPacer, int challengeLevel) {
+void Mediator::updateSettings(int breathPacer) {
     cout << "Updating Breath Pacer to " << breathPacer << endl;
-    cout << "Updating Challenge Level to " << challengeLevel << endl;
     this -> hv -> setBreathPacer(breathPacer);
 }
 

--- a/final/mediator.h
+++ b/final/mediator.h
@@ -13,7 +13,7 @@ class Mediator
 public:
     Mediator(MainWindow*);
 
-    void updateSettings(int, int);
+    void updateSettings(int);
     void updateUIElement(string);
     void updateBattery();
 


### PR DESCRIPTION
Added a bunch of disables and enables for UI stuff for when the heartwave battery dies. This will disable all the buttons and if a session is underway will stop it BUT WILL NOT print a summary and it will loose track of that session all together 
TODO -  will need to update the log class when we get to it as well

There is a bug but I am not sure how to fix it where we will need to click the power button twice before it turning on. It is minor not a huge deal but will look into it more when I have the time.